### PR TITLE
fix: Backend errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@
 /coverage
 
 # production
-/build
+**/build
 
 # misc
 .DS_Store

--- a/server/app.py
+++ b/server/app.py
@@ -3,6 +3,8 @@ import io
 import json
 import uuid
 import torch
+import asyncio
+import numpy as np
 from typing import Dict
 from scipy.io import wavfile
 from datetime import datetime
@@ -11,6 +13,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
 
 from modules.llm import GroqLLM
 from modules.stt import WhisperSTT
@@ -96,14 +99,17 @@ async def generate_report(data: dict):
     if not transcript:
         raise HTTPException(status_code=400, detail="Transcript is required")
     
-    transcript_text = "\n".join([item.get("text", "") for item in transcript])
-    
     async def generate():
-        for chunk in groq_llm.llm(transcript_text, is_full=True):
-            yield f"data: {json.dumps({'content': chunk})}\n\n"
-        yield f"data: {json.dumps({'done': True})}\n\n"
+        try:
+            for chunk in groq_llm.llm(transcript, is_full=True):
+                if chunk:
+                    yield f"data: {json.dumps({'content': chunk})}\n\n"
+            yield f"data: {json.dumps({'done': True})}\n\n"
+        except Exception as e:
+            print(f"Error in LLM generation: {e}")
+            yield f"data: {json.dumps({'error': str(e)})}\n\n"
     
-    return generate()
+    return StreamingResponse(generate(), media_type="text/event-stream")
 
 
 # ===== WEB SOCKETS =====
@@ -116,33 +122,46 @@ async def websocket_audio(websocket: WebSocket, session_id: str):
     session = sessions[session_id]
     await websocket.accept()
     
-    silence_threshold = 5
-    overlap_seconds = 2
-    
+    silence_threshold = 2
     accumulated_audio = None
     
     try:
         while True:
             data = await websocket.receive_bytes()
             
-            # Convert WebM to audio tensor
-            audio_tensor = process_webm_bytes(data, session.sample_rate)
+            # Append to session-specific webm buffer
+            session.webm_buffer.extend(data)
             
-            if audio_tensor is None:
-                await websocket.send_json({"type": "error", "message": "Failed to process audio"})
+            # Convert WebM to audio tensor using the full buffer
+            # Run in thread to avoid blocking the event loop heartbeats
+            full_audio_tensor = await asyncio.to_thread(
+                process_webm_bytes, bytes(session.webm_buffer), session_id, session.sample_rate
+            )
+            
+            if full_audio_tensor is None:
                 continue
             
-            # Append to accumulated audio
+            # Extract only the new part
+            current_total_samples = full_audio_tensor.shape[1]
+            new_samples_count = current_total_samples - session.last_processed_samples
+            
+            if new_samples_count <= 0:
+                continue
+                
+            audio_tensor = full_audio_tensor[:, session.last_processed_samples:]
+            session.last_processed_samples = current_total_samples
+            
+            # Append to accumulated audio (used for VAD and transcription)
             if accumulated_audio is None:
                 accumulated_audio = audio_tensor
             else:
                 accumulated_audio = torch.cat([accumulated_audio, audio_tensor], dim=1)
             
-            # Run VAD on accumulated audio
-            timestamps = silence_detector.get_timestamps_from_tensor(accumulated_audio, session.sample_rate)
-            
-            # Check for silence gaps
+            # Run VAD in thread
             current_audio_duration = accumulated_audio.shape[1] / session.sample_rate
+            timestamps = await asyncio.to_thread(
+                silence_detector.get_timestamps_from_tensor, accumulated_audio, session.sample_rate
+            )
             
             if len(timestamps) > 0:
                 last_timestamp = timestamps[-1]
@@ -152,46 +171,42 @@ async def websocket_audio(websocket: WebSocket, session_id: str):
                 silence_since_speech = current_audio_duration - speech_end
                 
                 if silence_since_speech >= silence_threshold:
-                    # Create chunk with overlap
-                    chunk_start = max(0, speech_end - overlap_seconds)
-                    chunk_end = current_audio_duration
+                    print(f"Silence threshold met ({silence_since_speech}s), transcribing...")
                     
-                    # Extract chunk
-                    start_sample = int(chunk_start * session.sample_rate)
-                    end_sample = int(chunk_end * session.sample_rate)
-                    audio_chunk = accumulated_audio[:, start_sample:end_sample]
+                    # Extract full accumulated chunk
+                    audio_chunk = accumulated_audio
                     
                     # Save to BytesIO (in-memory) and transcribe
                     audio_buffer = io.BytesIO()
                     audio_np = audio_chunk.squeeze().numpy()
-                    wavfile.write(audio_buffer, session.sample_rate, audio_np)
+                    
+                    # Convert to 16-bit PCM for broader compatibility
+                    audio_int16 = (audio_np * 32767).astype(np.int16)
+                    wavfile.write(audio_buffer, session.sample_rate, audio_int16)
                     audio_buffer.seek(0)
+                    audio_buffer.name = "audio.wav"
                     
-                    result = whisper_stt.stt(audio_buffer, language=session.language)
-                    result_dict = json.loads(result)
-                    text = result_dict.get("text", "")
+                    # Run STT in thread
+                    result = await asyncio.to_thread(
+                        whisper_stt.stt, audio_buffer, language=session.language
+                    )
                     
-                    if text.strip():
+                    if result and result.strip():
                         session.transcript.append({
-                            "text": text,
-                            "timestamp": chunk_start,
-                            "chunk_start": chunk_start,
-                            "chunk_end": chunk_end
+                            "text": result,
+                            "timestamp": 0,
+                            "chunk_start": 0,
+                            "chunk_end": current_audio_duration
                         })
                         
                         await websocket.send_json({
                             "type": "transcript",
-                            "text": text,
-                            "timestamp": chunk_start
+                            "text": result,
+                            "timestamp": 0
                         })
                     
-                    # Reset accumulated audio (keep a small buffer for overlap)
-                    keep_duration = overlap_seconds + 1
-                    keep_samples = int(keep_duration * session.sample_rate)
-                    if accumulated_audio.shape[1] > keep_samples:
-                        accumulated_audio = accumulated_audio[:, -keep_samples:]
-                    else:
-                        accumulated_audio = None
+                    # Reset accumulated audio
+                    accumulated_audio = None
             
             await websocket.send_json({
                 "type": "ack",
@@ -200,10 +215,16 @@ async def websocket_audio(websocket: WebSocket, session_id: str):
             })
             
     except WebSocketDisconnect:
-        pass
+        print("WebSocket connection closed")
     except Exception as e:
+        print(f"Error in websocket_audio: {e}")
+
         try:
             await websocket.send_json({"type": "error", "message": str(e)})
         except Exception:
             pass
-        await websocket.close(code=1011)
+        
+        try:
+            await websocket.close(code=1011)
+        except Exception:
+            pass

--- a/server/models/audio_session.py
+++ b/server/models/audio_session.py
@@ -1,12 +1,14 @@
-import torch
-from typing import List
+from typing import List, Optional
 from dataclasses import dataclass, field
+import torch
 
 @dataclass
 class Session:
     id: str
     language: str
     audio_buffer: List[torch.Tensor] = field(default_factory=list)
+    webm_buffer: bytearray = field(default_factory=bytearray)
+    last_processed_samples: int = 0
     transcript: List[dict] = field(default_factory=list)
     started_at: str = ""
     sample_rate: int = 16000

--- a/server/modules/silence_detector.py
+++ b/server/modules/silence_detector.py
@@ -34,7 +34,7 @@ class SilenceDetector:
         )
         return speech_timestamps
     
-    def detect_silence(self, audio_path, seconds=5):
+    def detect_silence(self, audio_path, seconds=2):
         speech_timestamps = self.get_timestamps(audio_path)
         silence_periods = []
         

--- a/server/modules/stt.py
+++ b/server/modules/stt.py
@@ -24,7 +24,7 @@ class WhisperSTT:
                 language=language,
                 temperature=0.0
             )
-            return json.dumps(transcription, indent=2, default=str)
+            return transcription.text
         finally:
             if close_file:
                 file.close()

--- a/server/utils/processors.py
+++ b/server/utils/processors.py
@@ -2,12 +2,25 @@ import io
 import torch
 from typing import Optional
 from pydub import AudioSegment
+import tempfile
+import os
 
 
-def process_webm_bytes(webm_bytes: bytes, target_sample_rate: int = 16000) -> Optional[torch.Tensor]:
+def process_webm_bytes(webm_bytes: bytes, session_id: str, target_sample_rate: int = 16000) -> Optional[torch.Tensor]:
     try:
-        audio = AudioSegment.from_file(io.BytesIO(webm_bytes), format="webm")
-        audio = audio.set_frame_rate(target_sample_rate).set_channels(1).set_sample_width(2)
+        print(f"Received {len(webm_bytes)} bytes for session {session_id}")
+    
+        tmp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix='.webm', delete=False) as tmp:
+                tmp.write(webm_bytes)
+                tmp_path = tmp.name
+            
+            audio = AudioSegment.from_file(tmp_path, format="webm")
+            audio = audio.set_frame_rate(target_sample_rate).set_channels(1).set_sample_width(2)
+        finally:
+            if tmp_path:
+                os.unlink(tmp_path)
         
         samples = torch.tensor(audio.get_array_of_samples(), dtype=torch.float32) / 32768.0
         samples = samples.unsqueeze(0)


### PR DESCRIPTION
- Updated the seconds to cut and pass the audio to the STT from 5 to 2
- Updated the `processors.py` file to use temporary files for better audio handling
- Updated the `stt.py` to return the text directly instead of a JSON
- Updated `audio_session.py` model file to include the values of `webm_buffer` and `last_processed_samples`
- Updated the whole `app.py` to fix different errors in the backend flow containing audio handling and the streaming response from the LLM for the report generation