### PR TITLE
chore: Increased max completion tokens

### DIFF
--- a/server/modules/llm.py
+++ b/server/modules/llm.py
@@ -27,7 +27,7 @@ class GroqLLM:
             model=self.model,
             temperature=0.1,
             top_p=1,
-            max_completion_tokens=1024,
+            max_completion_tokens=8192,
             stop=None,
             stream=True,
         )


### PR DESCRIPTION
- Increased the `max_completions_tokens` argument in the `server/modules/llm.py` from 1024 to 8192